### PR TITLE
fixed error: cannot convert str to float

### DIFF
--- a/comcot_picture.py
+++ b/comcot_picture.py
@@ -19,8 +19,7 @@ line3 = []
 for line in lines:
     line2 = line.split('\n')
     line2 = ''.join(line2)
-    line2 = line2.split('  ')
-    line2.remove('')
+    line2 = line2.split()
     line3 = line3 + line2
 print(line3)
 


### PR DESCRIPTION
it happen when trying to split string like '0.0003 -10.0061', because it is separated by 1 space, the COMCOT separates between floats with 1 space when it is a negative float and has more than 1 digit (in my case 2 digits) before decimal point.